### PR TITLE
Importing error aguamala.devops-docker-utils

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: your name
-  description:
+  description: Install/configure devops docker utils
   company: your company (optional)
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value


### PR DESCRIPTION
Cannot run ansible playbooks that use:
- src: aguamala.devops-docker-utils

Error:
   ami-devops-utils: - downloading role 'devops-docker-utils', owned by aguamala
    ami-devops-utils:  [WARNING]: - aguamala.devops-docker-utils was NOT installed successfully: -
    ami-devops-utils: **sorry, aguamala.devops-docker-utils was not found on
    ami-devops-utils: https://galaxy.ansible.com.**



When trying to import aguamala.ansible_role_devops_docker_utils into Ansible galaxy, this error happens:
===== IMPORTING ROLE: ansible_role_devops_docker_utils ===== 
Task "592006" failed: null value in column "description" violates not-null constraint DETAIL: Failing row contains (47184, null, 2020-03-12 18:49:39.683301+00, 2020-03-12 18:49:39.804578+00, t, ansible_role_devops_docker_utils, 1.2, license (GPLv2, CC-BY,